### PR TITLE
feat: update OpenAI prompts for analysis

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,4 @@
+module futuna
+
+go 1.21
+

--- a/internal/openai/client.go
+++ b/internal/openai/client.go
@@ -1,0 +1,31 @@
+package openai
+
+import "strings"
+
+const roleSystem = `Bạn là một chuyên gia phân tích tài chính. Mọi phản hồi phải ở dạng JSON thuần bằng tiếng Việt. Luôn sử dụng công cụ web_search để tìm thông tin trước khi trả lời.`
+
+const userPromptTemplate = `Phân tích các mã cổ phiếu sau: {{TICKERS}}.
+Cho mỗi mã, cung cấp:
+- short_term: {"recommendation", "confidence", "reason"}
+- long_term: {"recommendation", "confidence", "reason"}
+- strategies: ít nhất 5 mục [{"name", "stance", "note"}]
+Sau khi hoàn thành từng mã, đưa ra overall_recommendation: {"recommendation", "confidence", "justification"}.
+Cuối cùng, liệt kê sources: danh sách URL đã tham khảo.`
+
+func buildUserPrompt(tickers []string) string {
+	return strings.ReplaceAll(userPromptTemplate, "{{TICKERS}}", strings.Join(tickers, ", "))
+}
+
+// BuildMessages tạo danh sách thông điệp cho API OpenAI.
+func BuildMessages(tickers []string) []Message {
+	return []Message{
+		{Role: "system", Content: roleSystem},
+		{Role: "user", Content: buildUserPrompt(tickers)},
+	}
+}
+
+// Message đại diện cho một thông điệp gửi tới API OpenAI.
+type Message struct {
+	Role    string `json:"role"`
+	Content string `json:"content"`
+}


### PR DESCRIPTION
## Summary
- add OpenAI client with system message enforcing Vietnamese JSON and web_search usage
- update user prompt to capture short- and long-term views, at least five strategies, overall recommendation, and sources list

## Testing
- `go fmt ./...`
- `go vet ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68a7f7964920832c967e9e6eeb1c349d