### PR TITLE
feat: auto-install migrate tool

### DIFF
--- a/scripts/run-analyzer.sh
+++ b/scripts/run-analyzer.sh
@@ -4,5 +4,5 @@ set -e
 set -a
 . ./.env
 set +a
-migrate -path migrations -database "$DATABASE_URL" up
+./scripts/run-migrations.sh
 GO111MODULE=on go run ./cmd/analyzer

--- a/scripts/run-client.sh
+++ b/scripts/run-client.sh
@@ -4,5 +4,5 @@ set -e
 set -a
 . ./.env
 set +a
-migrate -path migrations -database "$DATABASE_URL" up
+./scripts/run-migrations.sh
 npm --prefix web run dev

--- a/scripts/run-dev.sh
+++ b/scripts/run-dev.sh
@@ -4,6 +4,6 @@ set -e
 set -a
 . ./.env
 set +a
-migrate -path migrations -database "$DATABASE_URL" up
+./scripts/run-migrations.sh
 ANALYZE_ON_START=1 GO111MODULE=on go run ./cmd/web &
 npm --prefix web run dev

--- a/scripts/run-migrations.sh
+++ b/scripts/run-migrations.sh
@@ -1,0 +1,18 @@
+#!/bin/sh
+# Ensure migrate CLI is installed and apply database migrations
+set -e
+
+# Determine installation directory for Go tools
+GOBIN="$(go env GOBIN)"
+if [ -z "$GOBIN" ]; then
+  GOBIN="$(go env GOPATH)/bin"
+fi
+
+MIGRATE_BIN="$(command -v migrate || true)"
+if [ -z "$MIGRATE_BIN" ]; then
+  echo "Installing migrate CLI..."
+  go install -tags 'postgres' github.com/golang-migrate/migrate/v4/cmd/migrate@latest
+  MIGRATE_BIN="$GOBIN/migrate"
+fi
+
+"$MIGRATE_BIN" -path migrations -database "$DATABASE_URL" up

--- a/scripts/run-web.sh
+++ b/scripts/run-web.sh
@@ -4,5 +4,5 @@ set -e
 set -a
 . ./.env
 set +a
-migrate -path migrations -database "$DATABASE_URL" up
+./scripts/run-migrations.sh
 GO111MODULE=on go run ./cmd/web


### PR DESCRIPTION
## Summary
- ensure migrate is installed before running DB migrations
- reuse new helper in dev scripts

## Testing
- `go test ./...` *(fails: missing go.sum entries)*
- `go mod tidy` *(fails: forbidden when downloading modules)*

------
https://chatgpt.com/codex/tasks/task_e_68a812b38620832c9b4cc4bb3602ff4d