### PR TITLE
chore: upgrade go-openai to v2

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module futuna
 go 1.21
 
 require (
- github.com/sashabaranov/go-openai v1.13.1
+ github.com/sashabaranov/go-openai/v2 v2.0.0
  github.com/joho/godotenv v1.5.1
  github.com/jackc/pgx/v5 v5.5.3
  github.com/jmoiron/sqlx v1.4.5

--- a/internal/openai/client.go
+++ b/internal/openai/client.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"encoding/json"
 
-	oa "github.com/sashabaranov/go-openai"
+	oa "github.com/sashabaranov/go-openai/v2"
 )
 
 // Client wraps the OpenAI API client.


### PR DESCRIPTION
## Summary
- upgrade `github.com/sashabaranov/go-openai` to v2
- adjust internal OpenAI client import for v2

## Testing
- `go mod tidy` *(fails: Get "https://proxy.golang.org/github.com/joho/godotenv/@v/v1.5.1.zip": Forbidden)*
- `go test ./...` *(fails: missing go.sum entry for module providing package github.com/jmoiron/sqlx/types)*
- `go get -u ./...` *(fails: Get "https://proxy.golang.org/github.com/go-chi/chi/v5/@v/v5.8.1.mod": Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68a82d8714bc832ca8cda4d017691812