### PR TITLE
Batch OpenAI ticker analysis

### DIFF
--- a/internal/analyzer/analyzer.go
+++ b/internal/analyzer/analyzer.go
@@ -14,7 +14,7 @@ import (
 
 // OpenAI defines interface to get analysis.
 type OpenAI interface {
-	AnalyzeTickers(ctx context.Context) (string, string, string, error)
+	AnalyzeTickers(ctx context.Context, tickers []string) (string, string, string, error)
 }
 
 // Service orchestrates OpenAI calls and persistence.
@@ -30,65 +30,80 @@ func NewService(db *sqlx.DB, llm OpenAI) *Service {
 
 // AnalyzeAllAndStore runs analysis for all tickers and saves to DB.
 func (s *Service) AnalyzeAllAndStore(ctx context.Context) error {
-	reqJSON, respJSON, result, err := s.llm.AnalyzeTickers(ctx)
+	tickers, err := s.ListTickers(ctx)
 	if err != nil {
 		return err
 	}
-	if _, err := s.db.ExecContext(ctx, `INSERT INTO openai_logs (request, response) VALUES ($1,$2)`, types.JSONText(reqJSON), types.JSONText(respJSON)); err != nil {
-		return err
+	symbols := make([]string, len(tickers))
+	for i, t := range tickers {
+		symbols[i] = t.Symbol
 	}
-	var payload struct {
-		AsOf    string `json:"as_of"`
-		Tickers []struct {
-			Ticker    string `json:"ticker"`
-			ShortTerm struct {
-				Recommendation string `json:"recommendation"`
-				Confidence     int    `json:"confidence"`
-				Reason         string `json:"reason"`
-			} `json:"short_term"`
-			LongTerm struct {
-				Recommendation string `json:"recommendation"`
-				Confidence     int    `json:"confidence"`
-				Reason         string `json:"reason"`
-			} `json:"long_term"`
-			Strategies []struct {
-				Name   string `json:"name"`
-				Stance string `json:"stance"`
-				Note   string `json:"note"`
-			} `json:"strategies"`
-			Overall struct {
-				Recommendation string `json:"recommendation"`
-				Confidence     int    `json:"confidence"`
-				Reason         string `json:"reason"`
-			} `json:"overall"`
-		} `json:"tickers"`
-		Sources []string `json:"sources"`
-	}
-	if err := json.Unmarshal([]byte(result), &payload); err != nil {
-		return err
-	}
-	date, err := time.Parse(time.RFC3339, payload.AsOf)
-	if err != nil {
-		date = time.Now()
-	}
-	date = date.Truncate(24 * time.Hour)
-	sourcesJSON, _ := json.Marshal(payload.Sources)
-	for _, item := range payload.Tickers {
-		if _, err := s.db.ExecContext(ctx, `INSERT INTO tickers (symbol) VALUES ($1) ON CONFLICT DO NOTHING`, item.Ticker); err != nil {
-			return err
+	for i := 0; i < len(symbols); i += 5 {
+		end := i + 5
+		if end > len(symbols) {
+			end = len(symbols)
 		}
-		short := fmt.Sprintf("%s - %s", item.ShortTerm.Recommendation, item.ShortTerm.Reason)
-		shortConf := item.ShortTerm.Confidence
-		long := fmt.Sprintf("%s - %s", item.LongTerm.Recommendation, item.LongTerm.Reason)
-		longConf := item.LongTerm.Confidence
-		overall := fmt.Sprintf("%s - %s", item.Overall.Recommendation, item.Overall.Reason)
-		overallConf := item.Overall.Confidence
-		strategiesJSON, _ := json.Marshal(item.Strategies)
-
-		_, err := s.db.ExecContext(ctx, `INSERT INTO analyses (ticker, analyzed_at, short_term, short_confidence, long_term, long_confidence, strategies, overall, overall_confidence, sources, created_at) VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,NOW()) ON CONFLICT (ticker, analyzed_at) DO UPDATE SET short_term=EXCLUDED.short_term, short_confidence=EXCLUDED.short_confidence, long_term=EXCLUDED.long_term, long_confidence=EXCLUDED.long_confidence, strategies=EXCLUDED.strategies, overall=EXCLUDED.overall, overall_confidence=EXCLUDED.overall_confidence, sources=EXCLUDED.sources`,
-			item.Ticker, date, short, shortConf, long, longConf, strategiesJSON, overall, overallConf, sourcesJSON)
+		batch := symbols[i:end]
+		reqJSON, respJSON, result, err := s.llm.AnalyzeTickers(ctx, batch)
 		if err != nil {
 			return err
+		}
+		if _, err := s.db.ExecContext(ctx, `INSERT INTO openai_logs (request, response) VALUES ($1,$2)`, types.JSONText(reqJSON), types.JSONText(respJSON)); err != nil {
+			return err
+		}
+		var payload struct {
+			AsOf    string `json:"as_of"`
+			Tickers []struct {
+				Ticker    string `json:"ticker"`
+				ShortTerm struct {
+					Recommendation string `json:"recommendation"`
+					Confidence     int    `json:"confidence"`
+					Reason         string `json:"reason"`
+				} `json:"short_term"`
+				LongTerm struct {
+					Recommendation string `json:"recommendation"`
+					Confidence     int    `json:"confidence"`
+					Reason         string `json:"reason"`
+				} `json:"long_term"`
+				Strategies []struct {
+					Name   string `json:"name"`
+					Stance string `json:"stance"`
+					Note   string `json:"note"`
+				} `json:"strategies"`
+				Overall struct {
+					Recommendation string `json:"recommendation"`
+					Confidence     int    `json:"confidence"`
+					Reason         string `json:"reason"`
+				} `json:"overall"`
+			} `json:"tickers"`
+			Sources []string `json:"sources"`
+		}
+		if err := json.Unmarshal([]byte(result), &payload); err != nil {
+			return err
+		}
+		date, err := time.Parse(time.RFC3339, payload.AsOf)
+		if err != nil {
+			date = time.Now()
+		}
+		date = date.Truncate(24 * time.Hour)
+		sourcesJSON, _ := json.Marshal(payload.Sources)
+		for _, item := range payload.Tickers {
+			if _, err := s.db.ExecContext(ctx, `INSERT INTO tickers (symbol) VALUES ($1) ON CONFLICT DO NOTHING`, item.Ticker); err != nil {
+				return err
+			}
+			short := fmt.Sprintf("%s - %s", item.ShortTerm.Recommendation, item.ShortTerm.Reason)
+			shortConf := item.ShortTerm.Confidence
+			long := fmt.Sprintf("%s - %s", item.LongTerm.Recommendation, item.LongTerm.Reason)
+			longConf := item.LongTerm.Confidence
+			overall := fmt.Sprintf("%s - %s", item.Overall.Recommendation, item.Overall.Reason)
+			overallConf := item.Overall.Confidence
+			strategiesJSON, _ := json.Marshal(item.Strategies)
+
+			_, err := s.db.ExecContext(ctx, `INSERT INTO analyses (ticker, analyzed_at, short_term, short_confidence, long_term, long_confidence, strategies, overall, overall_confidence, sources, created_at) VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,NOW()) ON CONFLICT (ticker, analyzed_at) DO UPDATE SET short_term=EXCLUDED.short_term, short_confidence=EXCLUDED.short_confidence, long_term=EXCLUDED.long_term, long_confidence=EXCLUDED.long_confidence, strategies=EXCLUDED.strategies, overall=EXCLUDED.overall, overall_confidence=EXCLUDED.overall_confidence, sources=EXCLUDED.sources`,
+				item.Ticker, date, short, shortConf, long, longConf, strategiesJSON, overall, overallConf, sourcesJSON)
+			if err != nil {
+				return err
+			}
 		}
 	}
 	return nil

--- a/internal/openai/client.go
+++ b/internal/openai/client.go
@@ -3,6 +3,8 @@ package openai
 import (
 	"context"
 	"encoding/json"
+	"fmt"
+	"strings"
 
 	openai "github.com/openai/openai-go/v2"
 	"github.com/openai/openai-go/v2/option"
@@ -22,87 +24,91 @@ func New(apiKey, baseURL, model string) *Client {
 	return &Client{api: openai.NewClient(opts...), model: model}
 }
 
-func (c *Client) AnalyzeTickers(ctx context.Context) (string, string, string, error) {
+func (c *Client) AnalyzeTickers(ctx context.Context, tickers []string) (string, string, string, error) {
+	if len(tickers) > 5 {
+		tickers = tickers[:5]
+	}
+	tickersList := strings.Join(tickers, ", ")
+
 	// --- your JSON Schema unchanged ---
 	schema := map[string]any{
 		"type":                 "object",
 		"additionalProperties": false,
 		"properties": map[string]any{
-		  "as_of": map[string]any{
-			"type":   "string",
-			"format": "date-time",
-		  },
-		  "tickers": map[string]any{
-			"type":     "array",
-			"minItems": 1,
-			"items": map[string]any{
-			  "type":                 "object",
-			  "additionalProperties": false,
-			  "properties": map[string]any{
-				"ticker": map[string]any{
-				  "type":    "string",
-				  "pattern": "^[A-Z]{3,5}$",
-				},
-				"short_term": map[string]any{
-				  "type":                 "object",
-				  "additionalProperties": false,
-				  "properties": map[string]any{
-					"recommendation": map[string]any{"type": "string", "enum": []string{"ACCUMULATE", "HOLD", "AVOID"}},
-					"confidence":     map[string]any{"type": "integer", "minimum": 0, "maximum": 100},
-					"reason":         map[string]any{"type": "string", "minLength": 1},
-				  },
-				  "required": []string{"recommendation", "confidence", "reason"},
-				},
-				"long_term": map[string]any{
-				  "type":                 "object",
-				  "additionalProperties": false,
-				  "properties": map[string]any{
-					"recommendation": map[string]any{"type": "string", "enum": []string{"ACCUMULATE", "HOLD", "AVOID"}},
-					"confidence":     map[string]any{"type": "integer", "minimum": 0, "maximum": 100},
-					"reason":         map[string]any{"type": "string", "minLength": 1},
-				  },
-				  "required": []string{"recommendation", "confidence", "reason"},
-				},
-				"strategies": map[string]any{
-				  "type":     "array",
-				  "minItems": 5,
-				  "items": map[string]any{
+			"as_of": map[string]any{
+				"type":   "string",
+				"format": "date-time",
+			},
+			"tickers": map[string]any{
+				"type":     "array",
+				"minItems": 1,
+				"maxItems": 5,
+				"items": map[string]any{
 					"type":                 "object",
 					"additionalProperties": false,
 					"properties": map[string]any{
-					  "name":   map[string]any{"type": "string", "minLength": 1},
-					  "stance": map[string]any{"type": "string", "enum": []string{"FAVORABLE", "NEUTRAL", "UNFAVORABLE"}},
-					  "note":   map[string]any{"type": "string", "minLength": 1},
+						"ticker": map[string]any{
+							"type":    "string",
+							"pattern": "^[A-Z]{3,5}$",
+						},
+						"short_term": map[string]any{
+							"type":                 "object",
+							"additionalProperties": false,
+							"properties": map[string]any{
+								"recommendation": map[string]any{"type": "string", "enum": []string{"ACCUMULATE", "HOLD", "AVOID"}},
+								"confidence":     map[string]any{"type": "integer", "minimum": 0, "maximum": 100},
+								"reason":         map[string]any{"type": "string", "minLength": 1},
+							},
+							"required": []string{"recommendation", "confidence", "reason"},
+						},
+						"long_term": map[string]any{
+							"type":                 "object",
+							"additionalProperties": false,
+							"properties": map[string]any{
+								"recommendation": map[string]any{"type": "string", "enum": []string{"ACCUMULATE", "HOLD", "AVOID"}},
+								"confidence":     map[string]any{"type": "integer", "minimum": 0, "maximum": 100},
+								"reason":         map[string]any{"type": "string", "minLength": 1},
+							},
+							"required": []string{"recommendation", "confidence", "reason"},
+						},
+						"strategies": map[string]any{
+							"type":     "array",
+							"minItems": 5,
+							"items": map[string]any{
+								"type":                 "object",
+								"additionalProperties": false,
+								"properties": map[string]any{
+									"name":   map[string]any{"type": "string", "minLength": 1},
+									"stance": map[string]any{"type": "string", "enum": []string{"FAVORABLE", "NEUTRAL", "UNFAVORABLE"}},
+									"note":   map[string]any{"type": "string", "minLength": 1},
+								},
+								"required": []string{"name", "stance", "note"},
+							},
+						},
+						"overall": map[string]any{
+							"type":                 "object",
+							"additionalProperties": false,
+							"properties": map[string]any{
+								"recommendation": map[string]any{"type": "string", "enum": []string{"ACCUMULATE", "HOLD", "AVOID"}},
+								"confidence":     map[string]any{"type": "integer", "minimum": 0, "maximum": 100},
+								"reason":         map[string]any{"type": "string", "minLength": 1},
+							},
+							"required": []string{"recommendation", "confidence", "reason"},
+						},
 					},
-					"required": []string{"name", "stance", "note"},
-				  },
+					"required": []string{"ticker", "short_term", "long_term", "strategies", "overall"},
 				},
-				"overall": map[string]any{
-				  "type":                 "object",
-				  "additionalProperties": false,
-				  "properties": map[string]any{
-					"recommendation": map[string]any{"type": "string", "enum": []string{"ACCUMULATE", "HOLD", "AVOID"}},
-					"confidence":     map[string]any{"type": "integer", "minimum": 0, "maximum": 100},
-					"reason":         map[string]any{"type": "string", "minLength": 1},
-				  },
-				  "required": []string{"recommendation", "confidence", "reason"},
+			},
+			"sources": map[string]any{
+				"type":     "array",
+				"minItems": 1,
+				"items": map[string]any{
+					"type": "string",
 				},
-			  },
-			  "required": []string{"ticker", "short_term", "long_term", "strategies", "overall"},
 			},
-		  },
-		  "sources": map[string]any{
-			"type":     "array",
-			"minItems": 1,
-			"items": map[string]any{
-			  "type":   "string",
-			},
-		  },
 		},
 		"required": []string{"as_of", "tickers", "sources"},
-	  }
-	  
-	  
+	}
 
 	// Build the minimal typed params (only what we must type)
 	params := responses.ResponseNewParams{
@@ -119,17 +125,17 @@ func (c *Client) AnalyzeTickers(ctx context.Context) (string, string, string, er
 	resp, err := c.api.Responses.New(
 		ctx,
 		params,
-        // Enable web search tool (try "web_search" first; some regions still use "..._preview")
-        option.WithJSONSet("tools", []map[string]any{
-            {"type": "web_search"},
-        }),
-        // Structured outputs under text.format (JSON Schema)
-        option.WithJSONSet("text.format", map[string]any{
-            "type": "json_schema",
+		// Enable web search tool (try "web_search" first; some regions still use "..._preview")
+		option.WithJSONSet("tools", []map[string]any{
+			{"type": "web_search"},
+		}),
+		// Structured outputs under text.format (JSON Schema)
+		option.WithJSONSet("text.format", map[string]any{
+			"type":   "json_schema",
 			"schema": schema,
 			"name":   "analysis_response",
-        }),
-		
+		}),
+
 		// Input messages
 		option.WithJSONSet("input", []map[string]any{
 			{
@@ -141,7 +147,7 @@ func (c *Client) AnalyzeTickers(ctx context.Context) (string, string, string, er
 			{
 				"type": "message", "role": "user",
 				"content": []map[string]any{
-					{"type": "input_text", "text": "Generate today’s 08:00 (GMT+7) HOSE analysis for all VN30. For each ticker, provide:\n1. Short-Term View\n   - Recommendation: (ACCUMULATE | HOLD | AVOID)\n   - Confidence (0-100)\n   - Reason\n2. Long-Term View\n   - Recommendation: (ACCUMULATE | HOLD | AVOID)\n   - Confidence (0-100)\n   - Reason\n3. Strategy-Based Analysis (at least 5 technical/fundamental strategies)\n   For each strategy:\n   - Strategy Name (e.g., Moving Average Crossover, RSI, Fibonacci, Momentum, Bollinger Bands, Fundamental PE Valuation, etc.)\n   - Stance: (FAVORABLE | NEUTRAL | UNFAVORABLE)\n   - Note: Explain why this stance is taken (indicator values, patterns, or signals observed).\n4. Final Overall Recommendation\n   - Aggregate the above strategy stances into a single recommendation (ACCUMULATE | HOLD | AVOID).\n   - Provide confidence score (0-100).\n   - Justify by balancing short-term vs long-term outlook and strategy signals.\n5. Sources\n   - Include relevant URLs used in the analysis. Response in Vietnamese only"},
+					{"type": "input_text", "text": fmt.Sprintf("Generate today’s 08:00 (GMT+7) HOSE analysis for the following tickers: %s. For each ticker, provide:\n1. Short-Term View\n   - Recommendation: (ACCUMULATE | HOLD | AVOID)\n   - Confidence (0-100)\n   - Reason\n2. Long-Term View\n   - Recommendation: (ACCUMULATE | HOLD | AVOID)\n   - Confidence (0-100)\n   - Reason\n3. Strategy-Based Analysis (at least 5 technical/fundamental strategies)\n   For each strategy:\n   - Strategy Name (e.g., Moving Average Crossover, RSI, Fibonacci, Momentum, Bollinger Bands, Fundamental PE Valuation, etc.)\n   - Stance: (FAVORABLE | NEUTRAL | UNFAVORABLE)\n   - Note: Explain why this stance is taken (indicator values, patterns, or signals observed).\n4. Final Overall Recommendation\n   - Aggregate the above strategy stances into a single recommendation (ACCUMULATE | HOLD | AVOID).\n   - Provide confidence score (0-100).\n   - Justify by balancing short-term vs long-term outlook and strategy signals.\n5. Sources\n   - Include relevant URLs used in the analysis. Response in Vietnamese only", tickersList)},
 				},
 			},
 		}),


### PR DESCRIPTION
## Summary
- Analyze tickers in batches of five from the database
- Restrict OpenAI prompt and schema to at most five tickers per request

## Testing
- `go build ./...` *(fails: github.com/jmoiron/sqlx@v1.4.0: Get "https://proxy.golang.org/...": Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68a887ac0564832cb876851f5307e933